### PR TITLE
Populate library.properties url field

### DIFF
--- a/NECIRrcv/library.properties
+++ b/NECIRrcv/library.properties
@@ -5,5 +5,5 @@ maintainer=Eduardo Cáceres de la Calle <edcaceres95@hotmail.com>
 sentence=Gets IR codes
 paragraph=This library allows an Arduino to get IR codes
 category=Display
-url=*
+url=https://github.com/eduherminio/NECIRrcv
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.